### PR TITLE
Fix aliases need to be public

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -15,8 +15,8 @@
 	        </call>
         </service>
 
-        <service id="sam_j_fractal.manager" alias="SamJ\FractalBundle\ContainerAwareManager" />
-        <service id="League\Fractal\Manager" alias="SamJ\FractalBundle\ContainerAwareManager" />
+        <service id="sam_j_fractal.manager" alias="SamJ\FractalBundle\ContainerAwareManager" public="true" />
+        <service id="League\Fractal\Manager" alias="SamJ\FractalBundle\ContainerAwareManager" public="true" />
 
     </services>
 </container>


### PR DESCRIPTION
Missed this, I thought that the aliases would be public by default but no. This fix ensures that the aliases aren't removed from the compiled container.