### PR TITLE
Replace Symfony container interface with PSR's

### DIFF
--- a/src/ContainerAwareManager.php
+++ b/src/ContainerAwareManager.php
@@ -5,10 +5,8 @@ namespace SamJ\FractalBundle;
 use League\Fractal\Manager;
 use League\Fractal\Resource\ResourceInterface;
 use League\Fractal\Scope;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-class ContainerAwareManager extends Manager implements ContainerAwareInterface
+class ContainerAwareManager extends Manager
 {
     use ContainerAwareTrait;
 

--- a/src/ContainerAwareScope.php
+++ b/src/ContainerAwareScope.php
@@ -3,10 +3,8 @@
 namespace SamJ\FractalBundle;
 
 use League\Fractal\Scope;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-class ContainerAwareScope extends Scope implements ContainerAwareInterface
+class ContainerAwareScope extends Scope
 {
     use ContainerAwareTrait;
 

--- a/src/ContainerAwareTrait.php
+++ b/src/ContainerAwareTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace SamJ\FractalBundle;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * ContainerAware trait.
+ */
+trait ContainerAwareTrait
+{
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+}


### PR DESCRIPTION
this PR allows us to use ServiceLocator instead of the whole container.